### PR TITLE
feat: Add GitHub Actions workflow for exa-mcp-server

### DIFF
--- a/.github/workflows/exa-mcp-server.yml
+++ b/.github/workflows/exa-mcp-server.yml
@@ -1,0 +1,43 @@
+name: Build and Push Docker Image - exa-mcp-server
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  push:
+    paths:
+      - .github/workflows/exa-mcp-server.yml
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout exa-mcp-server code
+        uses: actions/checkout@main
+        with:
+          repository: exa-labs/exa-mcp-server
+          path: exa-mcp-server
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build And Push the Docker image
+        env:
+          IMAGE: exa-mcp-server
+        run: |
+          cd ./exa-mcp-server
+          docker build . --file Dockerfile --tag $IMAGE
+
+          docker tag $IMAGE "kulabun/$IMAGE:latest"
+          docker push "kulabun/$IMAGE:latest"
+
+          docker tag $IMAGE "kulabun/$IMAGE:$(date +%s)"
+          docker push "kulabun/$IMAGE:$(date +%s)"


### PR DESCRIPTION
This commit adds a new GitHub Actions workflow to build the `exa-labs/exa-mcp-server` repository and publish the resulting Docker image to Docker Hub.